### PR TITLE
feat: add github action packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+       - '*'
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload production-ready build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: production-files
+          path: ./dist


### PR DESCRIPTION
- 添加前端页面打包的工作流

已测试通过：https://github.com/d0zingcat/jproxy-admin/actions/runs/5571315293

我设想中可以在后端项目中直接移除前端代码，在后端打包 docker 镜像的时候实时下载最新的前端 artifacts ，以此实现前后端的分离。一个简单的例子：

```yaml
      - name: Download artifact
        id: download-artifact
        uses: dawidd6/action-download-artifact@v2
        with:
          name: production-files
          repo: d0zingcat/jproxy-admin
          workflow: build.yml
          path: ./resources/static
          search_artifacts: true
```